### PR TITLE
refactor mojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,62 @@ This plugin provides goal for generating hollow consumer api, that is
 described [here](http://hollow.how/getting-started/#consumer-api-generation)
 
 ## Usage
-In order to use, add plugin to your `pom.xml` file and configure it
+The hollow api generator works on compiled classes. The easiest way to work with this 
+is using multiple maven modules like this: 
+
+```xml
+<modules>
+    <module>my-hollow-domain-objects</module>
+    <module>my-hollow-consumer-api</module>
+    <module>my-hollow-publisher</module>
+</modules> 
 ```
+
+
+ 
+In a project that has a dependency on your domain classes, you can then set up the plugin like this: 
+```xml
+<dependencies>
+   ... 
+   <dependency>
+        <groupId>my.groupId</groupId>
+        <artifactId>my.artifactId</artifactId>
+        <version>my.version</version>
+        <!-- there's no need for the domain definition files 
+             to be included transitively by other modules, so you can 
+             mark this dependency as "optional" -->
+        <optional>true</optional>
+    <dependency>
+    ...  
+```
+       
+and in your plugins section:
+```xml
+
+
 <plugin>
     <groupId>com.github.igorperikov</groupId>
     <artifactId>hollow-maven-plugin</artifactId>
-    <version>0.1.1</version>
-    <configuration>
-        <packagesToScan>
-            <param>org.example.package1</param>
-            <param>org.example.package2</param>
-        </packagesToScan>
-        <apiClassName>MyApiClassName</apiClassName>
-        <apiPackageName>org.example.package3.generated.api</apiPackageName>
-    </configuration>
+    <version>0.1.2</version>
+
+    <executions>
+        <execution>
+            <id>generate-hollow-stufff</id>
+            <phase>generate-sources</phase>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+            <configuration>
+                <packagesToScan>
+                    <param>org.example.package1</param>
+                    <param>org.example.package2</param>
+                </packagesToScan>
+                <apiClassName>MyApiClassName</apiClassName>
+                <apiPackageName>org.example.package3.generated.api</apiPackageName>
+            </configuration>
+        </execution>
+    </executions>
+    
 </plugin>
 ```
 
@@ -27,9 +69,7 @@ where:
 - `apiClassName` - class name for your [api implementation](https://github.com/Netflix/hollow/blob/master/hollow/src/main/java/com/netflix/hollow/api/custom/HollowAPI.java) 
 - `apiPackageName` - target package in your project for api-related sources
 
-launch task:
+when running a normal build (e.g. `mvn clean install`) the generator plugin will scan the compile classpath of its dependencies,
+generate sources under the `target/generated-sources/hollow` directory, and then add those to the compilation phase so that 
+the end result will be a jar that contains the generated api that you can then use to consume the hollow data.
 
-`mvn compile hollow:generate`
-
-N.B. it is important to launch `compile` before `hollow:generate`
-because plugin needs .class files to generate consumer api

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In order to use, add plugin to your `pom.xml` file and configure it
 <plugin>
     <groupId>com.github.igorperikov</groupId>
     <artifactId>hollow-maven-plugin</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <configuration>
         <packagesToScan>
             <param>org.example.package1</param>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.igorperikov</groupId>
     <artifactId>hollow-maven-plugin</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Hollow maven plugin</name>
@@ -24,7 +25,7 @@
         <connection>scm:git:git://github.com/IgorPerikov/hollow-maven-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:IgorPerikov/hollow-maven-plugin.git</developerConnection>
         <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <developers>
         <developer>
@@ -44,20 +45,44 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>3.1.1</version>
+            <artifactId>maven-core</artifactId>
+            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>3.1.1</version>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.2.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.1</version>
-            <scope>provided</scope>
+            <version>3.4</version>
         </dependency>
+
+        <!-- for finding the dependencies -->
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.11</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.lukehutch</groupId>
+            <artifactId>fast-classpath-scanner</artifactId>
+            <version>LATEST</version>
+        </dependency>
+
 
         <dependency>
             <groupId>com.netflix.hollow</groupId>
@@ -88,27 +113,27 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.5</version>
                 <configuration>
                     <goalPrefix>hollow</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-gpg-plugin</artifactId>-->
+                <!--<version>1.6</version>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>sign-artifacts</id>-->
+                        <!--<phase>verify</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>sign</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- generate sources in an a 'generated-sources' directory
- include those generated sources in the build so that they get compiled
- document new way to use this mojo

The primary motivation was to make it possible to have a project build from scratch and automatically generate the client stuff without requiring the generated code to be committed to version control.

It also eliminates the need to do the two-step "compile" / "generate" steps because maven takes care of that for you if you use it in a multi-module configuration