### PR TITLE
Add classPostfix parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ You can use plugin in two different configurations:
 - `useErgonomicShortcuts`
 - `usePackageGrouping`
 - `restrictApiToFieldType`
+- `classPostfix`
 
 default values for those params can be found [here](/src/main/java/com/github/igorperikov/hollow/mojo/AbstractHollowMojo.java)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.igorperikov</groupId>
     <artifactId>hollow-maven-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Hollow maven plugin</name>

--- a/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
+++ b/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
@@ -43,7 +43,7 @@ public class HollowAPIGeneratorUtility {
                 .reservePrimaryKeyIndexForTypeWithPrimaryKey(properties.reservePrimaryKeyIndexForTypeWithPrimaryKey)
                 .withHollowPrimitiveTypes(properties.useHollowPrimitiveTypes)
                 .withVerboseToString(properties.useVerboseToString)
-				.withClassPostfix(properties.classPostfix);
+                .withClassPostfix(properties.classPostfix);
         if (properties.useErgonomicShortcuts) {
             builder.withErgonomicShortcuts();
         }

--- a/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
+++ b/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
@@ -42,7 +42,8 @@ public class HollowAPIGeneratorUtility {
                 .withBooleanFieldErgonomics(properties.useBooleanFieldErgonomics)
                 .reservePrimaryKeyIndexForTypeWithPrimaryKey(properties.reservePrimaryKeyIndexForTypeWithPrimaryKey)
                 .withHollowPrimitiveTypes(properties.useHollowPrimitiveTypes)
-                .withVerboseToString(properties.useVerboseToString);
+                .withVerboseToString(properties.useVerboseToString)
+				.withClassPostfix(properties.classPostfix);
         if (properties.useErgonomicShortcuts) {
             builder.withErgonomicShortcuts();
         }

--- a/src/main/java/com/github/igorperikov/hollow/config/OptionalHollowProperties.java
+++ b/src/main/java/com/github/igorperikov/hollow/config/OptionalHollowProperties.java
@@ -11,7 +11,7 @@ public class OptionalHollowProperties {
             boolean useErgonomicShortcuts,
             boolean usePackageGrouping,
             boolean restrictApiToFieldType,
-			String classPostfix
+            String classPostfix
     ) {
         this.parameterizeAllClassNames = parameterizeAllClassNames;
         this.useAggressiveSubstitutions = useAggressiveSubstitutions;
@@ -22,7 +22,7 @@ public class OptionalHollowProperties {
         this.useErgonomicShortcuts = useErgonomicShortcuts;
         this.usePackageGrouping = usePackageGrouping;
         this.restrictApiToFieldType = restrictApiToFieldType;
-		this.classPostfix = classPostfix;
+        this.classPostfix = classPostfix;
     }
 
     public final boolean parameterizeAllClassNames;
@@ -34,5 +34,5 @@ public class OptionalHollowProperties {
     public final boolean useErgonomicShortcuts;
     public final boolean usePackageGrouping;
     public final boolean restrictApiToFieldType;
-	public final String classPostfix;
+    public final String classPostfix;
 }

--- a/src/main/java/com/github/igorperikov/hollow/config/OptionalHollowProperties.java
+++ b/src/main/java/com/github/igorperikov/hollow/config/OptionalHollowProperties.java
@@ -10,7 +10,8 @@ public class OptionalHollowProperties {
             boolean useVerboseToString,
             boolean useErgonomicShortcuts,
             boolean usePackageGrouping,
-            boolean restrictApiToFieldType
+            boolean restrictApiToFieldType,
+			String classPostfix
     ) {
         this.parameterizeAllClassNames = parameterizeAllClassNames;
         this.useAggressiveSubstitutions = useAggressiveSubstitutions;
@@ -21,6 +22,7 @@ public class OptionalHollowProperties {
         this.useErgonomicShortcuts = useErgonomicShortcuts;
         this.usePackageGrouping = usePackageGrouping;
         this.restrictApiToFieldType = restrictApiToFieldType;
+		this.classPostfix = classPostfix;
     }
 
     public final boolean parameterizeAllClassNames;
@@ -32,4 +34,5 @@ public class OptionalHollowProperties {
     public final boolean useErgonomicShortcuts;
     public final boolean usePackageGrouping;
     public final boolean restrictApiToFieldType;
+	public final String classPostfix;
 }

--- a/src/main/java/com/github/igorperikov/hollow/mojo/AbstractHollowMojo.java
+++ b/src/main/java/com/github/igorperikov/hollow/mojo/AbstractHollowMojo.java
@@ -45,4 +45,7 @@ public abstract class AbstractHollowMojo extends AbstractMojo {
 
     @Parameter(property = "restrictApiToFieldType", required = false, defaultValue = "true")
     public boolean restrictApiToFieldType;
+
+    @Parameter(property = "classPostfix", required = false, defaultValue = "")
+    public String classPostfix;
 }

--- a/src/main/java/com/github/igorperikov/hollow/mojo/MultiModuleHollowMojo.java
+++ b/src/main/java/com/github/igorperikov/hollow/mojo/MultiModuleHollowMojo.java
@@ -44,7 +44,7 @@ public class MultiModuleHollowMojo extends AbstractHollowMojo {
                         useErgonomicShortcuts,
                         usePackageGrouping,
                         restrictApiToFieldType,
-						classPostfix
+                        classPostfix
                 )
         );
 

--- a/src/main/java/com/github/igorperikov/hollow/mojo/MultiModuleHollowMojo.java
+++ b/src/main/java/com/github/igorperikov/hollow/mojo/MultiModuleHollowMojo.java
@@ -43,7 +43,8 @@ public class MultiModuleHollowMojo extends AbstractHollowMojo {
                         useVerboseToString,
                         useErgonomicShortcuts,
                         usePackageGrouping,
-                        restrictApiToFieldType
+                        restrictApiToFieldType,
+						classPostfix
                 )
         );
 

--- a/src/main/java/com/github/igorperikov/hollow/mojo/SingleModuleHollowMojo.java
+++ b/src/main/java/com/github/igorperikov/hollow/mojo/SingleModuleHollowMojo.java
@@ -33,7 +33,7 @@ public class SingleModuleHollowMojo extends AbstractHollowMojo {
                         useErgonomicShortcuts,
                         usePackageGrouping,
                         restrictApiToFieldType,
-						classPostfix
+                        classPostfix
                 )
         );
 

--- a/src/main/java/com/github/igorperikov/hollow/mojo/SingleModuleHollowMojo.java
+++ b/src/main/java/com/github/igorperikov/hollow/mojo/SingleModuleHollowMojo.java
@@ -32,7 +32,8 @@ public class SingleModuleHollowMojo extends AbstractHollowMojo {
                         useVerboseToString,
                         useErgonomicShortcuts,
                         usePackageGrouping,
-                        restrictApiToFieldType
+                        restrictApiToFieldType,
+						classPostfix
                 )
         );
 


### PR DESCRIPTION
Unlike the [HollowAPIGenerator constructor](https://github.com/Netflix/hollow/blob/master/hollow/src/main/java/com/netflix/hollow/api/codegen/HollowAPIGenerator.java#L119), the [AbstractHollowAPIGeneratorBuilder](https://github.com/Netflix/hollow/blob/master/hollow/src/main/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorBuilder.java#L40) does not provide a default value of "Hollow" for the generated class name suffix. So as of version 1.0.0 the maven plugin generates classes with no suffix. This was not what I wanted to I added an optional maven plugin parameter so I can specify the suffix I want via the [AbstractHollowAPIGeneratorBuilder.withClassPostfix method](https://github.com/Netflix/hollow/blob/master/hollow/src/main/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorBuilder.java#L81).