### PR TITLE
Make class postfix optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.22</version>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.igorperikov</groupId>
     <artifactId>hollow-maven-plugin</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Hollow maven plugin</name>

--- a/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
+++ b/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
@@ -55,7 +55,7 @@ public class HollowAPIGeneratorUtility {
         if (properties.restrictApiToFieldType) {
             builder.withRestrictApiToFieldType();
         }
-        if(isNotBlank(properties.classPostfix)) {
+        if (isNotBlank(properties.classPostfix)) {
             builder.withClassPostfix(properties.classPostfix);
         }
         return builder.build();

--- a/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
+++ b/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
@@ -1,5 +1,7 @@
 package com.github.igorperikov.hollow;
 
+import static org.codehaus.plexus.util.StringUtils.isNotBlank;
+
 import com.github.igorperikov.hollow.config.OptionalHollowProperties;
 import com.github.igorperikov.hollow.utils.ClasspathUtils;
 import com.netflix.hollow.api.codegen.HollowAPIGenerator;
@@ -42,8 +44,8 @@ public class HollowAPIGeneratorUtility {
                 .withBooleanFieldErgonomics(properties.useBooleanFieldErgonomics)
                 .reservePrimaryKeyIndexForTypeWithPrimaryKey(properties.reservePrimaryKeyIndexForTypeWithPrimaryKey)
                 .withHollowPrimitiveTypes(properties.useHollowPrimitiveTypes)
-                .withVerboseToString(properties.useVerboseToString)
-                .withClassPostfix(properties.classPostfix);
+                .withVerboseToString(properties.useVerboseToString);
+
         if (properties.useErgonomicShortcuts) {
             builder.withErgonomicShortcuts();
         }
@@ -52,6 +54,9 @@ public class HollowAPIGeneratorUtility {
         }
         if (properties.restrictApiToFieldType) {
             builder.withRestrictApiToFieldType();
+        }
+        if(!isNotBlank(properties.classPostfix)) {
+            builder.withClassPostfix(properties.classPostfix);
         }
         return builder.build();
     }

--- a/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
+++ b/src/main/java/com/github/igorperikov/hollow/HollowAPIGeneratorUtility.java
@@ -55,7 +55,7 @@ public class HollowAPIGeneratorUtility {
         if (properties.restrictApiToFieldType) {
             builder.withRestrictApiToFieldType();
         }
-        if(!isNotBlank(properties.classPostfix)) {
+        if(isNotBlank(properties.classPostfix)) {
             builder.withClassPostfix(properties.classPostfix);
         }
         return builder.build();


### PR DESCRIPTION
This fixes: #14.

I've added a dependency on plexus-utils for StringUtils.isNotBlank using the same version that was already on the runtime classpath via `maven-core` (and others).